### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -327,4 +327,5 @@ def get_appointment(apt_id):
     return jsonify({'success': True, 'appointment': apt_dict})
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 'yes']
+    app.run(debug=debug_mode, host='0.0.0.0', port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/Robbs-Playground/np-scheduler/security/code-scanning/1](https://github.com/Robbs-Playground/np-scheduler/security/code-scanning/1)

To fix the issue, we will remove the hardcoded `debug=True` from the `app.run()` call and replace it with a configuration that determines the debug mode based on an environment variable. This approach ensures that debug mode is only enabled explicitly during development and not accidentally in production.

**Steps to fix:**
1. Import the `os` module if not already imported (it is already imported in this case).
2. Replace the `app.run(debug=True, ...)` line with a version that sets `debug` based on an environment variable, such as `FLASK_DEBUG`.
3. Provide a default value of `False` for the `debug` parameter to ensure it is disabled if the environment variable is not set.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
